### PR TITLE
1 supabase realtime을 사용한 멀티 디스플레이 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+config.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 config.js
+.cursor/
+.cursor/mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,30 @@
+# ========== 환경/비밀 ==========
 .env
+.env.local
+.env.*.local
 config.js
+
+# ========== 의존성 / 빌드 ==========
+node_modules/
+dist/
+*.local
+
+# ========== IDE / 에디터 ==========
 .cursor/
-.cursor/mcp.json
+.vscode/
+*.swp
+*.swo
+*~
+
+# ========== OS ==========
+.DS_Store
+Thumbs.db
+
+# ========== 로그 / 캐시 ==========
+*.log
+npm-debug.log*
+.npm/
+.cache/
+
+# ========== 기타 ==========
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
       <aside class="panel" id="control-panel">
         <h1>Lighting POC</h1>
 
-        <section class="group" id="display-section">
-          <h2>디스플레이</h2>
+        <details class="group" id="display-section">
+          <summary>디스플레이</summary>
           <div class="row">
             <label class="grow">
               <span>적용 대상</span>
@@ -41,10 +41,10 @@
               </select>
             </label>
           </div>
-        </section>
+        </details>
 
-        <section class="group">
-          <h2>패널</h2>
+        <details class="group">
+          <summary>패널</summary>
           <div class="row">
             <button id="togglePanelBtn" type="button">패널 숨기기 (P)</button>
             <button id="toggleDockBtn" type="button">
@@ -52,10 +52,10 @@
             </button>
             <span id="panelDockState" class="muted small">현재: 왼쪽</span>
           </div>
-        </section>
+        </details>
 
-        <section class="group">
-          <h2>프리셋</h2>
+        <details class="group">
+          <summary>프리셋</summary>
           <div class="row">
             <span class="grow">불러오기/내보내기 적용 범위</span>
           </div>
@@ -91,10 +91,10 @@
             </label>
           </div>
           <p class="hint">현재 설정을 저장/불러오기 합니다.</p>
-        </section>
+        </details>
 
-        <section class="group">
-          <h2>배경 색상</h2>
+        <details class="group">
+          <summary>배경 색상</summary>
           <div class="row">
             <button id="bg-black" type="button">검정</button>
             <button id="bg-gray" type="button">회색</button>
@@ -103,7 +103,7 @@
               <input id="bgColor" type="color" value="#000000" />
             </label>
           </div>
-        </section>
+        </details>
 
         <details class="group">
           <summary>생성 모양</summary>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,19 @@
         <section class="group">
           <h2>프리셋</h2>
           <div class="row">
+            <span class="grow">불러오기/내보내기 적용 범위</span>
+          </div>
+          <div class="row">
+            <label
+              ><input type="radio" name="presetScope" value="current" checked />
+              현재 디스플레이만</label
+            >
+            <label
+              ><input type="radio" name="presetScope" value="all" /> 모든
+              디스플레이</label
+            >
+          </div>
+          <div class="row">
             <button id="exportPresetBtn" type="button">Export JSON</button>
             <button id="importPresetBtn" type="button">Import JSON</button>
             <input

--- a/index.html
+++ b/index.html
@@ -7,6 +7,22 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="nav-page" class="nav-page" hidden>
+      <div class="nav-inner">
+        <h1 class="nav-title">Lighting POC</h1>
+        <p class="nav-desc">컨트롤 또는 디스플레이를 선택하세요.</p>
+        <nav class="nav-links">
+          <a href="?role=control" class="nav-link nav-link-control">컨트롤</a>
+          <a href="?role=display&displayId=1" class="nav-link">Display 1</a>
+          <a href="?role=display&displayId=2" class="nav-link">Display 2</a>
+          <a href="?role=display&displayId=3" class="nav-link">Display 3</a>
+          <a href="?role=display&displayId=4" class="nav-link">Display 4</a>
+          <a href="?role=display&displayId=5" class="nav-link">Display 5</a>
+          <a href="?role=display&displayId=6" class="nav-link">Display 6</a>
+        </nav>
+      </div>
+    </div>
+    <div id="app-page" class="app-page" hidden>
     <aside class="panel" id="control-panel">
       <h1>Lighting POC</h1>
 
@@ -450,9 +466,26 @@
       class="canvas-container"
       aria-label="canvas"
     ></main>
+    </div>
 
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        var role = params.get("role");
+        var nav = document.getElementById("nav-page");
+        var app = document.getElementById("app-page");
+        if (role === "control" || role === "display") {
+          if (nav) nav.hidden = true;
+          if (app) app.hidden = false;
+        } else {
+          if (nav) nav.hidden = false;
+          if (app) app.hidden = true;
+        }
+      })();
+    </script>
     <script src="config.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+    <script src="supabase.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/p5@1.9.2/lib/p5.min.js"></script>
     <script src="main.js"></script>
     <script src="ui.js"></script>

--- a/index.html
+++ b/index.html
@@ -393,8 +393,8 @@
             </label>
           </div>
           <p id="blockerColorHint" class="hint" style="display: none">
-            Filter에서 흰색은 투과 100%에 가까워 효과가 거의 없을 수 있어요.
-            흰 판이 필요하면 Solid를 사용하세요.
+            Filter에서 흰색은 투과 100%에 가까워 효과가 거의 없을 수 있어요. 흰
+            판이 필요하면 Solid를 사용하세요.
           </p>
 
           <div class="row">
@@ -433,6 +433,8 @@
       aria-label="canvas"
     ></main>
 
+    <script src="config.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/p5@1.9.2/lib/p5.min.js"></script>
     <script src="main.js"></script>
     <script src="ui.js"></script>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,24 @@
     <aside class="panel" id="control-panel">
       <h1>Lighting POC</h1>
 
+      <section class="group" id="display-section">
+        <h2>디스플레이</h2>
+        <div class="row">
+          <label class="grow">
+            <span>적용 대상</span>
+            <select id="displaySelect">
+              <option value="all">전체</option>
+              <option value="1">Display 1</option>
+              <option value="2">Display 2</option>
+              <option value="3">Display 3</option>
+              <option value="4">Display 4</option>
+              <option value="5">Display 5</option>
+              <option value="6">Display 6</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
       <section class="group">
         <h2>패널</h2>
         <div class="row">

--- a/index.html
+++ b/index.html
@@ -509,26 +509,8 @@
       ></main>
     </div>
 
-    <script>
-      (function () {
-        var params = new URLSearchParams(window.location.search);
-        var role = params.get("role");
-        var nav = document.getElementById("nav-page");
-        var app = document.getElementById("app-page");
-        if (role === "control" || role === "display") {
-          if (nav) nav.hidden = true;
-          if (app) app.hidden = false;
-        } else {
-          if (nav) nav.hidden = false;
-          if (app) app.hidden = true;
-        }
-      })();
-    </script>
-    <script src="config.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
-    <script src="supabase.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/p5@1.9.2/lib/p5.min.js"></script>
-    <script src="main.js"></script>
-    <script src="ui.js"></script>
+    <script type="module" src="/nav.js"></script>
+    <script type="module" src="/main.js"></script>
+    <script type="module" src="/ui.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,459 +13,487 @@
         <p class="nav-desc">컨트롤 또는 디스플레이를 선택하세요.</p>
         <nav class="nav-links">
           <a href="?role=control" class="nav-link nav-link-control">컨트롤</a>
-          <a href="?role=display&displayId=1" class="nav-link">Display 1</a>
-          <a href="?role=display&displayId=2" class="nav-link">Display 2</a>
-          <a href="?role=display&displayId=3" class="nav-link">Display 3</a>
-          <a href="?role=display&displayId=4" class="nav-link">Display 4</a>
-          <a href="?role=display&displayId=5" class="nav-link">Display 5</a>
-          <a href="?role=display&displayId=6" class="nav-link">Display 6</a>
+          <a href="?role=display&displayId=1" class="nav-link">Top</a>
+          <a href="?role=display&displayId=2" class="nav-link">Bottom</a>
+          <a href="?role=display&displayId=3" class="nav-link">Left</a>
+          <a href="?role=display&displayId=4" class="nav-link">Right</a>
+          <a href="?role=display&displayId=5" class="nav-link">Front</a>
+          <a href="?role=display&displayId=6" class="nav-link">Back</a>
         </nav>
       </div>
     </div>
     <div id="app-page" class="app-page" hidden>
-    <aside class="panel" id="control-panel">
-      <h1>Lighting POC</h1>
+      <aside class="panel" id="control-panel">
+        <h1>Lighting POC</h1>
 
-      <section class="group" id="display-section">
-        <h2>디스플레이</h2>
-        <div class="row">
-          <label class="grow">
-            <span>적용 대상</span>
-            <select id="displaySelect">
-              <option value="all">전체</option>
-              <option value="1">Display 1</option>
-              <option value="2">Display 2</option>
-              <option value="3">Display 3</option>
-              <option value="4">Display 4</option>
-              <option value="5">Display 5</option>
-              <option value="6">Display 6</option>
-            </select>
-          </label>
-        </div>
-      </section>
-
-      <section class="group">
-        <h2>패널</h2>
-        <div class="row">
-          <button id="togglePanelBtn" type="button">패널 숨기기 (P)</button>
-          <button id="toggleDockBtn" type="button">오른쪽으로 이동 (D)</button>
-          <span id="panelDockState" class="muted small">현재: 왼쪽</span>
-        </div>
-      </section>
-
-      <section class="group">
-        <h2>프리셋</h2>
-        <div class="row">
-          <button id="exportPresetBtn" type="button">Export JSON</button>
-          <button id="importPresetBtn" type="button">Import JSON</button>
-          <input
-            id="importPresetFile"
-            type="file"
-            accept="application/json"
-            style="display: none"
-          />
-        </div>
-        <div class="row">
-          <label class="grow">
-            <span>Export 파일명 (빈칸이면 자동)</span>
-            <input
-              id="presetFileName"
-              type="text"
-              placeholder="예: studio_A_softbox_v2"
-              autocomplete="off"
-            />
-          </label>
-        </div>
-        <p class="hint">현재 설정을 저장/불러오기 합니다.</p>
-      </section>
-
-      <section class="group">
-        <h2>배경 색상</h2>
-        <div class="row">
-          <button id="bg-black" type="button">검정</button>
-          <button id="bg-gray" type="button">회색</button>
-          <label class="grow right">
-            <span>팔레트</span>
-            <input id="bgColor" type="color" value="#000000" />
-          </label>
-        </div>
-      </section>
-
-      <details class="group">
-        <summary>생성 모양</summary>
-        <div class="row">
-          <label
-            ><input type="radio" name="shape" value="circle" checked />
-            원형</label
-          >
-          <label><input type="radio" name="shape" value="rect" /> 사각형</label>
-        </div>
-        <p class="hint">캔버스를 클릭하면 현재 모양으로 조명이 생성됩니다.</p>
-      </details>
-
-      <details class="group">
-        <summary>전역 노출(톤매핑)</summary>
-        <label class="row">
-          <button
-            type="button"
-            class="step-btn"
-            id="exposureMinus"
-            title="-0.01"
-          >
-            −
-          </button>
-          <input
-            id="exposureSlider"
-            type="range"
-            min="0.1"
-            max="5"
-            step="0.01"
-            value="1.2"
-          />
-          <button
-            type="button"
-            class="step-btn"
-            id="exposurePlus"
-            title="+0.01"
-          >
-            +
-          </button>
-          <output id="exposureValue">1.20</output>
-        </label>
-      </details>
-
-      <details class="group">
-        <summary>전역 튜닝</summary>
-        <label class="row">
-          <span class="grow">Falloff Strength</span>
-          <button
-            type="button"
-            class="step-btn"
-            id="falloffCMinus"
-            title="-0.1"
-          >
-            −
-          </button>
-          <input
-            id="falloffCSlider"
-            type="range"
-            min="0.2"
-            max="6.0"
-            step="0.1"
-            value="2.0"
-          />
-          <button type="button" class="step-btn" id="falloffCPlus" title="+0.1">
-            +
-          </button>
-          <output id="falloffCValue">2.0</output>
-        </label>
-      </details>
-
-      <details class="group" open>
-        <summary>선택된 조명 속성</summary>
-        <div id="no-selection" class="muted">
-          조명을 선택하면 속성이 표시됩니다.
-        </div>
-
-        <div id="light-controls" class="stack" aria-disabled="true">
+        <section class="group" id="display-section">
+          <h2>디스플레이</h2>
           <div class="row">
             <label class="grow">
-              <span>Type</span>
-              <select id="selectedType" disabled>
-                <option value="LIGHT">Light</option>
-                <option value="FILTER">Filter</option>
-                <option value="SOLID">Solid</option>
+              <span>적용 대상</span>
+              <select id="displaySelect">
+                <option value="1">Top</option>
+                <option value="2">Bottom</option>
+                <option value="3">Left</option>
+                <option value="4">Right</option>
+                <option value="5">Front</option>
+                <option value="6">Back</option>
               </select>
             </label>
           </div>
-          <div id="circle-size" class="row">
-            <button type="button" class="step-btn" id="sizeMinus" title="-1">
-              −
+        </section>
+
+        <section class="group">
+          <h2>패널</h2>
+          <div class="row">
+            <button id="togglePanelBtn" type="button">패널 숨기기 (P)</button>
+            <button id="toggleDockBtn" type="button">
+              오른쪽으로 이동 (D)
             </button>
+            <span id="panelDockState" class="muted small">현재: 왼쪽</span>
+          </div>
+        </section>
+
+        <section class="group">
+          <h2>프리셋</h2>
+          <div class="row">
+            <button id="exportPresetBtn" type="button">Export JSON</button>
+            <button id="importPresetBtn" type="button">Import JSON</button>
+            <input
+              id="importPresetFile"
+              type="file"
+              accept="application/json"
+              style="display: none"
+            />
+          </div>
+          <div class="row">
             <label class="grow">
-              <span>크기 (Size)</span>
+              <span>Export 파일명 (빈칸이면 자동)</span>
               <input
-                id="sizeSlider"
-                type="range"
-                min="10"
-                max="1200"
-                step="1"
-                value="300"
-                disabled
+                id="presetFileName"
+                type="text"
+                placeholder="예: studio_A_softbox_v2"
+                autocomplete="off"
               />
             </label>
-            <button type="button" class="step-btn" id="sizePlus" title="+1">
+          </div>
+          <p class="hint">현재 설정을 저장/불러오기 합니다.</p>
+        </section>
+
+        <section class="group">
+          <h2>배경 색상</h2>
+          <div class="row">
+            <button id="bg-black" type="button">검정</button>
+            <button id="bg-gray" type="button">회색</button>
+            <label class="grow right">
+              <span>팔레트</span>
+              <input id="bgColor" type="color" value="#000000" />
+            </label>
+          </div>
+        </section>
+
+        <details class="group">
+          <summary>생성 모양</summary>
+          <div class="row">
+            <label
+              ><input type="radio" name="shape" value="circle" checked />
+              원형</label
+            >
+            <label
+              ><input type="radio" name="shape" value="rect" /> 사각형</label
+            >
+          </div>
+          <p class="hint">캔버스를 클릭하면 현재 모양으로 조명이 생성됩니다.</p>
+        </details>
+
+        <details class="group">
+          <summary>전역 노출(톤매핑)</summary>
+          <label class="row">
+            <button
+              type="button"
+              class="step-btn"
+              id="exposureMinus"
+              title="-0.01"
+            >
+              −
+            </button>
+            <input
+              id="exposureSlider"
+              type="range"
+              min="0.1"
+              max="5"
+              step="0.01"
+              value="1.2"
+            />
+            <button
+              type="button"
+              class="step-btn"
+              id="exposurePlus"
+              title="+0.01"
+            >
               +
             </button>
-            <output id="sizeValue">300</output>
+            <output id="exposureValue">1.20</output>
+          </label>
+        </details>
+
+        <details class="group">
+          <summary>전역 튜닝</summary>
+          <label class="row">
+            <span class="grow">Falloff Strength</span>
+            <button
+              type="button"
+              class="step-btn"
+              id="falloffCMinus"
+              title="-0.1"
+            >
+              −
+            </button>
+            <input
+              id="falloffCSlider"
+              type="range"
+              min="0.2"
+              max="6.0"
+              step="0.1"
+              value="2.0"
+            />
+            <button
+              type="button"
+              class="step-btn"
+              id="falloffCPlus"
+              title="+0.1"
+            >
+              +
+            </button>
+            <output id="falloffCValue">2.0</output>
+          </label>
+        </details>
+
+        <details class="group" open>
+          <summary>선택된 조명 속성</summary>
+          <div id="no-selection" class="muted">
+            조명을 선택하면 속성이 표시됩니다.
           </div>
 
-          <div id="rect-size" class="col">
+          <div id="light-controls" class="stack" aria-disabled="true">
             <div class="row">
-              <button type="button" class="step-btn" id="widthMinus" title="-1">
+              <label class="grow">
+                <span>Type</span>
+                <select id="selectedType" disabled>
+                  <option value="LIGHT">Light</option>
+                  <option value="FILTER">Filter</option>
+                  <option value="SOLID">Solid</option>
+                </select>
+              </label>
+            </div>
+            <div id="circle-size" class="row">
+              <button type="button" class="step-btn" id="sizeMinus" title="-1">
                 −
               </button>
               <label class="grow">
-                <span>가로</span>
+                <span>크기 (Size)</span>
                 <input
-                  id="widthSlider"
+                  id="sizeSlider"
                   type="range"
                   min="10"
-                  max="1600"
+                  max="1200"
                   step="1"
-                  value="220"
+                  value="300"
                   disabled
                 />
               </label>
-              <button type="button" class="step-btn" id="widthPlus" title="+1">
+              <button type="button" class="step-btn" id="sizePlus" title="+1">
                 +
               </button>
-              <output id="widthValue">220</output>
+              <output id="sizeValue">300</output>
             </div>
+
+            <div id="rect-size" class="col">
+              <div class="row">
+                <button
+                  type="button"
+                  class="step-btn"
+                  id="widthMinus"
+                  title="-1"
+                >
+                  −
+                </button>
+                <label class="grow">
+                  <span>가로</span>
+                  <input
+                    id="widthSlider"
+                    type="range"
+                    min="10"
+                    max="1600"
+                    step="1"
+                    value="220"
+                    disabled
+                  />
+                </label>
+                <button
+                  type="button"
+                  class="step-btn"
+                  id="widthPlus"
+                  title="+1"
+                >
+                  +
+                </button>
+                <output id="widthValue">220</output>
+              </div>
+              <div class="row">
+                <button
+                  type="button"
+                  class="step-btn"
+                  id="heightMinus"
+                  title="-1"
+                >
+                  −
+                </button>
+                <label class="grow">
+                  <span>세로</span>
+                  <input
+                    id="heightSlider"
+                    type="range"
+                    min="10"
+                    max="1200"
+                    step="1"
+                    value="160"
+                    disabled
+                  />
+                </label>
+                <button
+                  type="button"
+                  class="step-btn"
+                  id="heightPlus"
+                  title="+1"
+                >
+                  +
+                </button>
+                <output id="heightValue">160</output>
+              </div>
+            </div>
+
+            <div id="ellipse-controls" class="col" style="display: none">
+              <div class="row">
+                <label class="grow">
+                  <span>Size X (ratio)</span>
+                  <input
+                    id="sizeXSlider"
+                    type="range"
+                    min="0.1"
+                    max="3"
+                    step="0.01"
+                    value="1"
+                    disabled
+                  />
+                </label>
+                <output id="sizeXValue">1.00</output>
+              </div>
+              <div class="row">
+                <label class="grow">
+                  <span>Size Y (ratio)</span>
+                  <input
+                    id="sizeYSlider"
+                    type="range"
+                    min="0.1"
+                    max="3"
+                    step="0.01"
+                    value="1"
+                    disabled
+                  />
+                </label>
+                <output id="sizeYValue">1.00</output>
+              </div>
+              <div class="row" style="gap: 8px">
+                <button id="makeCircleByXBtn" type="button" disabled>
+                  X=Y (use X)
+                </button>
+                <button id="makeCircleByYBtn" type="button" disabled>
+                  X=Y (use Y)
+                </button>
+              </div>
+            </div>
+
             <div class="row">
               <button
                 type="button"
                 class="step-btn"
-                id="heightMinus"
+                id="brightnessMinus"
                 title="-1"
               >
                 −
               </button>
               <label class="grow">
-                <span>세로</span>
+                <span id="brightnessLabel">밝기 (HDR Intensity)</span>
                 <input
-                  id="heightSlider"
+                  id="brightnessSlider"
                   type="range"
-                  min="10"
-                  max="1200"
+                  min="0"
+                  max="2000"
                   step="1"
-                  value="160"
+                  value="300"
                   disabled
                 />
               </label>
-              <button type="button" class="step-btn" id="heightPlus" title="+1">
+              <button
+                type="button"
+                class="step-btn"
+                id="brightnessPlus"
+                title="+1"
+              >
                 +
               </button>
-              <output id="heightValue">160</output>
+              <output id="brightnessValue">300</output>
             </div>
-          </div>
 
-          <div id="ellipse-controls" class="col" style="display: none">
             <div class="row">
+              <button
+                type="button"
+                class="step-btn"
+                id="opacityMinus"
+                title="-0.01"
+              >
+                −
+              </button>
               <label class="grow">
-                <span>Size X (ratio)</span>
+                <span id="opacityLabel">Opacity</span>
                 <input
-                  id="sizeXSlider"
+                  id="opacitySlider"
                   type="range"
-                  min="0.1"
-                  max="3"
+                  min="0"
+                  max="1"
                   step="0.01"
                   value="1"
                   disabled
                 />
               </label>
-              <output id="sizeXValue">1.00</output>
+              <button
+                type="button"
+                class="step-btn"
+                id="opacityPlus"
+                title="+0.01"
+              >
+                +
+              </button>
+              <output id="opacityValue">1.00</output>
             </div>
+            <div id="opacityDebug" class="muted small">
+              selected light opacity = 1.00
+            </div>
+
             <div class="row">
+              <button
+                type="button"
+                class="step-btn"
+                id="softnessMinus"
+                title="-5"
+              >
+                −
+              </button>
               <label class="grow">
-                <span>Size Y (ratio)</span>
+                <span>페더 (Feather)</span>
                 <input
-                  id="sizeYSlider"
+                  id="softnessSlider"
                   type="range"
-                  min="0.1"
-                  max="3"
-                  step="0.01"
-                  value="1"
+                  min="0"
+                  max="800"
+                  step="5"
+                  value="150"
                   disabled
                 />
               </label>
-              <output id="sizeYValue">1.00</output>
-            </div>
-            <div class="row" style="gap: 8px">
-              <button id="makeCircleByXBtn" type="button" disabled>
-                X=Y (use X)
+              <button
+                type="button"
+                class="step-btn"
+                id="softnessPlus"
+                title="+5"
+              >
+                +
               </button>
-              <button id="makeCircleByYBtn" type="button" disabled>
-                X=Y (use Y)
+              <output id="softnessValue">150</output>
+            </div>
+
+            <div class="row">
+              <button
+                type="button"
+                class="step-btn"
+                id="falloffMinus"
+                title="-0.1"
+              >
+                −
+              </button>
+              <label class="grow">
+                <span>Falloff (1/r² 계수)</span>
+                <input
+                  id="falloffSlider"
+                  type="range"
+                  min="0.1"
+                  max="8"
+                  step="0.1"
+                  value="1.5"
+                  disabled
+                />
+              </label>
+              <button
+                type="button"
+                class="step-btn"
+                id="falloffPlus"
+                title="+0.1"
+              >
+                +
+              </button>
+              <output id="falloffValue">1.5</output>
+            </div>
+            <div id="falloffHint" class="muted small" style="display: none">
+              Feather가 0이면 Falloff 효과가 거의 없습니다.
+            </div>
+
+            <div class="row">
+              <label class="grow right">
+                <span>색상</span>
+                <input id="lightColor" type="color" value="#ffffff" disabled />
+              </label>
+            </div>
+            <p id="blockerColorHint" class="hint" style="display: none">
+              Filter에서 흰색은 투과 100%에 가까워 효과가 거의 없을 수 있어요.
+              흰 판이 필요하면 Solid를 사용하세요.
+            </p>
+
+            <div class="row">
+              <button id="fitCanvasBtn" type="button" disabled>
+                화면 꽉 채우기
+              </button>
+            </div>
+            <div class="row">
+              <button id="deleteLightBtn" type="button" disabled>
+                선택 조명 삭제
               </button>
             </div>
           </div>
+        </details>
 
+        <details class="group" open>
+          <summary>레이어 목록</summary>
           <div class="row">
-            <button
-              type="button"
-              class="step-btn"
-              id="brightnessMinus"
-              title="-1"
-            >
-              −
-            </button>
-            <label class="grow">
-              <span id="brightnessLabel">밝기 (HDR Intensity)</span>
-              <input
-                id="brightnessSlider"
-                type="range"
-                min="0"
-                max="2000"
-                step="1"
-                value="300"
-                disabled
-              />
-            </label>
-            <button
-              type="button"
-              class="step-btn"
-              id="brightnessPlus"
-              title="+1"
-            >
-              +
-            </button>
-            <output id="brightnessValue">300</output>
-          </div>
-
-          <div class="row">
-            <button
-              type="button"
-              class="step-btn"
-              id="opacityMinus"
-              title="-0.01"
-            >
-              −
-            </button>
-            <label class="grow">
-              <span id="opacityLabel">Opacity</span>
-              <input
-                id="opacitySlider"
-                type="range"
-                min="0"
-                max="1"
-                step="0.01"
-                value="1"
-                disabled
-              />
-            </label>
-            <button
-              type="button"
-              class="step-btn"
-              id="opacityPlus"
-              title="+0.01"
-            >
-              +
-            </button>
-            <output id="opacityValue">1.00</output>
-          </div>
-          <div id="opacityDebug" class="muted small">
-            selected light opacity = 1.00
-          </div>
-
-          <div class="row">
-            <button
-              type="button"
-              class="step-btn"
-              id="softnessMinus"
-              title="-5"
-            >
-              −
-            </button>
-            <label class="grow">
-              <span>페더 (Feather)</span>
-              <input
-                id="softnessSlider"
-                type="range"
-                min="0"
-                max="800"
-                step="5"
-                value="150"
-                disabled
-              />
-            </label>
-            <button type="button" class="step-btn" id="softnessPlus" title="+5">
-              +
-            </button>
-            <output id="softnessValue">150</output>
-          </div>
-
-          <div class="row">
-            <button
-              type="button"
-              class="step-btn"
-              id="falloffMinus"
-              title="-0.1"
-            >
-              −
-            </button>
-            <label class="grow">
-              <span>Falloff (1/r² 계수)</span>
-              <input
-                id="falloffSlider"
-                type="range"
-                min="0.1"
-                max="8"
-                step="0.1"
-                value="1.5"
-                disabled
-              />
-            </label>
-            <button
-              type="button"
-              class="step-btn"
-              id="falloffPlus"
-              title="+0.1"
-            >
-              +
-            </button>
-            <output id="falloffValue">1.5</output>
-          </div>
-          <div id="falloffHint" class="muted small" style="display: none">
-            Feather가 0이면 Falloff 효과가 거의 없습니다.
-          </div>
-
-          <div class="row">
-            <label class="grow right">
-              <span>색상</span>
-              <input id="lightColor" type="color" value="#ffffff" disabled />
-            </label>
-          </div>
-          <p id="blockerColorHint" class="hint" style="display: none">
-            Filter에서 흰색은 투과 100%에 가까워 효과가 거의 없을 수 있어요. 흰
-            판이 필요하면 Solid를 사용하세요.
-          </p>
-
-          <div class="row">
-            <button id="fitCanvasBtn" type="button" disabled>
-              화면 꽉 채우기
-            </button>
+            <button id="addLightBtn" type="button">+ Light</button>
+            <button id="addFilterBtn" type="button">+ Filter</button>
+            <button id="addSolidBtn" type="button">+ Solid</button>
           </div>
           <div class="row">
-            <button id="deleteLightBtn" type="button" disabled>
-              선택 조명 삭제
-            </button>
+            <button id="btnBringToFront" type="button">Bring to Front</button>
+            <button id="btnSendToBack" type="button">Send to Back</button>
           </div>
-        </div>
-      </details>
+          <div id="layerList" class="stack"></div>
+        </details>
 
-      <details class="group" open>
-        <summary>레이어 목록</summary>
-        <div class="row">
-          <button id="addLightBtn" type="button">+ Light</button>
-          <button id="addFilterBtn" type="button">+ Filter</button>
-          <button id="addSolidBtn" type="button">+ Solid</button>
-        </div>
-        <div class="row">
-          <button id="btnBringToFront" type="button">Bring to Front</button>
-          <button id="btnSendToBack" type="button">Send to Back</button>
-        </div>
-        <div id="layerList" class="stack"></div>
-      </details>
+        <footer class="muted small">클릭: 생성/선택 · 드래그: 이동</footer>
+      </aside>
 
-      <footer class="muted small">클릭: 생성/선택 · 드래그: 이동</footer>
-    </aside>
-
-    <main
-      id="canvas-container"
-      class="canvas-container"
-      aria-label="canvas"
-    ></main>
+      <main
+        id="canvas-container"
+        class="canvas-container"
+        aria-label="canvas"
+      ></main>
     </div>
 
     <script>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,8 @@
 /* p5.js sketch and WebGL shader-based light rendering */
+import "./supabase.js";
+import p5 from "p5";
 
+let p5Sketch;
 let p5Canvas;
 let glShader;
 
@@ -222,216 +225,218 @@ function initRealtime() {
   });
 }
 
-function preload() {
-  // load vertex/fragment shaders
-  glShader = loadShader("shader.vert", "shader.frag");
-}
+function initP5Sketch() {
+  new p5((p) => {
+    p5Sketch = p;
 
-function setup() {
-  const container = document.getElementById("canvas-container");
-  const w = container.clientWidth;
-  const h = window.innerHeight;
-  p5Canvas = createCanvas(w, h, WEBGL);
-  p5Canvas.parent("canvas-container");
-  pixelDensity(1);
-  noStroke();
+    p.preload = function () {
+      glShader = p.loadShader("shader.vert", "shader.frag");
+    };
 
-  initRealtime();
+    p.setup = function () {
+      const container = document.getElementById("canvas-container");
+      const w = container ? container.clientWidth : 800;
+      const h = window.innerHeight;
+      p5Canvas = p.createCanvas(w, h, p.WEBGL);
+      p5Canvas.parent("canvas-container");
+      p.pixelDensity(1);
+      p.noStroke();
 
-  dispatchEvent(new Event("app:ready"));
-}
+      initRealtime();
 
-function windowResized() {
-  const container = document.getElementById("canvas-container");
-  const w = container.clientWidth;
-  const h = window.innerHeight;
-  resizeCanvas(w, h);
-  dispatchEvent(
-    new CustomEvent("app:canvasResized", { detail: { width: w, height: h } })
-  );
-}
+      dispatchEvent(new Event("app:ready"));
+    };
 
-function draw() {
-  // Clear previous frame to avoid overlay (2D stroke) ghosting
-  background(0);
-  // Use shader to render full-screen quad
-  shader(glShader);
-  uploadUniforms();
-  // draw rect covering entire canvas; set (0,0) origin center in WEBGL, so use -w/2, -h/2
-  rectMode(CENTER);
-  // Ensure full coverage
-  rect(0, 0, width, height);
-  resetShader();
+    p.windowResized = function () {
+      const container = document.getElementById("canvas-container");
+      const w = container ? container.clientWidth : 800;
+      const h = window.innerHeight;
+      p.resizeCanvas(w, h);
+      dispatchEvent(
+        new CustomEvent("app:canvasResized", { detail: { width: w, height: h } })
+      );
+    };
 
-  if (appConfig.role === "control") {
-    updateHoverState();
-    if (appState.previewMode) return;
+    p.draw = function () {
+      p.background(0);
+      p.shader(glShader);
+      uploadUniforms();
+      p.rectMode(p.CENTER);
+      p.rect(0, 0, p.width, p.height);
+      p.resetShader();
 
-    // selection/hover overlay (in pixel-top-left space)
-    const selected = getSelectedLight();
-    const hovered =
-      appState.hoveredIdx >= 0 && appState.hoveredIdx < appState.lights.length
-        ? appState.lights[appState.hoveredIdx]
-        : null;
-    if (selected || hovered) {
-      push();
-      // map top-left (0,0) to WEBGL coordinates
-      resetMatrix();
-      translate(-width / 2, -height / 2, 0);
-      noFill();
+      if (appConfig.role === "control") {
+        updateHoverState();
+        if (appState.previewMode) return;
 
-      if (selected) {
-        if (isBlockerType(selected.type)) {
-          noStroke();
-          fill(255, 15);
-          drawHighlightShape(selected);
-          noFill();
+        const selected = getSelectedLight();
+        const hovered =
+          appState.hoveredIdx >= 0 && appState.hoveredIdx < appState.lights.length
+            ? appState.lights[appState.hoveredIdx]
+            : null;
+        if (selected || hovered) {
+          p.push();
+          p.resetMatrix();
+          p.translate(-p.width / 2, -p.height / 2, 0);
+          p.noFill();
+
+          if (selected) {
+            if (isBlockerType(selected.type)) {
+              p.noStroke();
+              p.fill(255, 15);
+              drawHighlightShape(selected);
+              p.noFill();
+            }
+            p.stroke(0);
+            p.strokeWeight(3.5);
+            drawHighlightShape(selected);
+            p.stroke(255);
+            p.strokeWeight(1.5);
+            drawHighlightShape(selected);
+            drawBlockerDash(selected);
+          }
+
+          if (hovered && (!selected || hovered.id !== selected.id)) {
+            p.stroke(0, 100);
+            p.strokeWeight(2.5);
+            drawHighlightShape(hovered);
+            p.stroke(255, 200);
+            p.strokeWeight(1.5);
+            drawHighlightShape(hovered);
+            drawBlockerDash(hovered);
+          }
+          p.pop();
         }
-        stroke(0);
-        strokeWeight(3.5);
-        drawHighlightShape(selected);
-        stroke(255);
-        strokeWeight(1.5);
-        drawHighlightShape(selected);
-        drawBlockerDash(selected);
       }
+    };
 
-      if (hovered && (!selected || hovered.id !== selected.id)) {
-        stroke(0, 100);
-        strokeWeight(2.5);
-        drawHighlightShape(hovered);
-        stroke(255, 200);
-        strokeWeight(1.5);
-        drawHighlightShape(hovered);
-        drawBlockerDash(hovered);
+    p.mousePressed = function () {
+      if (appConfig.role === "display") return;
+      if (isPointerOverPanel()) return;
+      if (!isMouseOnCanvas()) return;
+
+      const idx = hitTest(p5Sketch.mouseX, p5Sketch.mouseY);
+      if (idx !== -1) {
+        const light = appState.lights[idx];
+        appState.selectedLightId = light.id;
+        appState.dragging = true;
+        appState.dragOffset.x = p5Sketch.mouseX - light.x;
+        appState.dragOffset.y = p5Sketch.mouseY - light.y;
+        emitSelectionChange();
+        dispatchLightsChanged();
+        scheduleSyncToDisplay();
+      } else {
+        const light = createLightAt(
+          p5Sketch.mouseX,
+          p5Sketch.mouseY,
+          appState.creationShape,
+          appState.creationType
+        );
+        appState.lights.push(light);
+        appState.selectedLightId = light.id;
+        appState.dragging = true;
+        appState.dragOffset.x = 0;
+        appState.dragOffset.y = 0;
+        emitSelectionChange();
+        dispatchLightsChanged();
+        scheduleSyncToDisplay();
       }
-      pop();
-    }
-  }
+    };
+
+    p.mouseDragged = function () {
+      if (appConfig.role === "display") return;
+      if (isPointerOverPanel()) return;
+      if (!appState.dragging) return;
+      const selected = getSelectedLight();
+      if (!selected) return;
+      selected.x = p5Sketch.mouseX - appState.dragOffset.x;
+      selected.y = p5Sketch.mouseY - appState.dragOffset.y;
+      scheduleSyncToDisplay();
+    };
+
+    p.mouseReleased = function () {
+      if (appConfig.role === "display") return;
+      if (isPointerOverPanel()) return;
+      appState.dragging = false;
+    };
+
+    p.doubleClicked = function () {
+      if (appConfig.role === "display") return;
+      if (isPointerOverPanel()) return;
+      if (!isMouseOnCanvas()) return;
+      const idx = hitTest(p5Sketch.mouseX, p5Sketch.mouseY);
+      if (idx === -1) return;
+      const removed = appState.lights.splice(idx, 1)[0];
+      if (!removed) return;
+      if (appState.selectedLightId === removed.id) {
+        appState.selectedLightId = null;
+        emitSelectionChange();
+      }
+      dispatchLightsChanged();
+      scheduleSyncToDisplay();
+    };
+
+    p.mouseMoved = function () {
+      if (appConfig.role === "display") return;
+      updateHoverState();
+    };
+  });
 }
 
 function drawHighlightShape(light) {
-  if (!light) return;
+  if (!light || !p5Sketch) return;
   if (light.shape === "circle") {
     const sx = Number(light.sizeX) || 1;
     const sy = Number(light.sizeY) || 1;
     const rx = Math.max(1, (light.radius || 0) * sx);
     const ry = Math.max(1, (light.radius || 0) * sy);
     if (Math.abs(sx - 1) > 0.001 || Math.abs(sy - 1) > 0.001) {
-      push();
-      translate(light.x, light.y);
-      rotate(light.rotation || 0);
-      ellipse(0, 0, rx * 2, ry * 2);
-      pop();
+      p5Sketch.push();
+      p5Sketch.translate(light.x, light.y);
+      p5Sketch.rotate(light.rotation || 0);
+      p5Sketch.ellipse(0, 0, rx * 2, ry * 2);
+      p5Sketch.pop();
     } else {
-      circle(light.x, light.y, (light.radius || 0) * 2);
+      p5Sketch.circle(light.x, light.y, (light.radius || 0) * 2);
     }
   } else {
-    rectMode(CENTER);
-    rect(light.x, light.y, light.width, light.height, 4);
+    p5Sketch.rectMode(p5Sketch.CENTER);
+    p5Sketch.rect(light.x, light.y, light.width, light.height, 4);
   }
 }
 
 function drawBlockerDash(light) {
-  if (!light || !isBlockerType(light.type)) return;
-  const ctx = drawingContext;
+  if (!light || !isBlockerType(light.type) || !p5Sketch) return;
+  const ctx = p5Sketch.drawingContext;
   if (!ctx || typeof ctx.setLineDash !== "function") return;
   ctx.setLineDash([5, 5]);
-  stroke(255);
-  strokeWeight(1.25);
+  p5Sketch.stroke(255);
+  p5Sketch.strokeWeight(1.25);
   drawHighlightShape(light);
   ctx.setLineDash([]);
 }
 
 // ============ Input/Interaction ============
-function mousePressed() {
-  if (appConfig.role === "display") return;
-  if (isPointerOverPanel()) return;
-  if (!isMouseOnCanvas()) return;
-
-  // Try select topmost light under cursor
-  const idx = hitTest(mouseX, mouseY);
-  if (idx !== -1) {
-    const light = appState.lights[idx];
-    appState.selectedLightId = light.id;
-    appState.dragging = true;
-    appState.dragOffset.x = mouseX - light.x;
-    appState.dragOffset.y = mouseY - light.y;
-    emitSelectionChange();
-    dispatchLightsChanged();
-    scheduleSyncToDisplay();
-  } else {
-    // create new light
-    const light = createLightAt(
-      mouseX,
-      mouseY,
-      appState.creationShape,
-      appState.creationType
-    );
-    appState.lights.push(light);
-    appState.selectedLightId = light.id;
-    appState.dragging = true;
-    appState.dragOffset.x = 0;
-    appState.dragOffset.y = 0;
-    emitSelectionChange();
-    dispatchLightsChanged();
-    scheduleSyncToDisplay();
-  }
-}
-
-function mouseDragged() {
-  if (appConfig.role === "display") return;
-  if (isPointerOverPanel()) return;
-  if (!appState.dragging) return;
-  const selected = getSelectedLight();
-  if (!selected) return;
-  selected.x = mouseX - appState.dragOffset.x;
-  selected.y = mouseY - appState.dragOffset.y;
-  scheduleSyncToDisplay();
-}
-
-function mouseMoved() {
-  if (appConfig.role === "display") return;
-  updateHoverState();
-}
-
-function mouseReleased() {
-  if (appConfig.role === "display") return;
-  if (isPointerOverPanel()) return;
-  appState.dragging = false;
-}
-
-// Delete by double click on a light
-function doubleClicked() {
-  if (appConfig.role === "display") return;
-  if (isPointerOverPanel()) return;
-  if (!isMouseOnCanvas()) return;
-  const idx = hitTest(mouseX, mouseY);
-  if (idx === -1) return;
-  const removed = appState.lights.splice(idx, 1)[0];
-  if (!removed) return;
-  if (appState.selectedLightId === removed.id) {
-    appState.selectedLightId = null;
-    emitSelectionChange();
-  }
-  dispatchLightsChanged();
-  scheduleSyncToDisplay();
-}
-
 function isMouseOnCanvas() {
-  return mouseX >= 0 && mouseX <= width && mouseY >= 0 && mouseY <= height;
+  if (!p5Sketch) return false;
+  return (
+    p5Sketch.mouseX >= 0 &&
+    p5Sketch.mouseX <= p5Sketch.width &&
+    p5Sketch.mouseY >= 0 &&
+    p5Sketch.mouseY <= p5Sketch.height
+  );
 }
 
 function isPointerOverPanel() {
-  if (document.body.classList.contains("panel-hidden")) return false;
+  if (!p5Sketch || document.body.classList.contains("panel-hidden")) return false;
   const panel = document.getElementById("control-panel");
   if (!panel) return false;
   const canvasEl = p5Canvas && p5Canvas.elt;
   if (!canvasEl) return false;
 
   const c = canvasEl.getBoundingClientRect();
-  const clientX = c.left + mouseX;
-  const clientY = c.top + mouseY;
+  const clientX = c.left + p5Sketch.mouseX;
+  const clientY = c.top + p5Sketch.mouseY;
   const r = panel.getBoundingClientRect();
   return (
     clientX >= r.left &&
@@ -461,7 +466,7 @@ function hitTest(x, y) {
         const ny = py / ry;
         if (nx * nx + ny * ny <= 1.0) return i;
       } else {
-        const d = dist(x, y, l.x, l.y);
+        const d = Math.hypot(x - l.x, y - l.y);
         if (d <= l.radius) return i;
       }
     } else {
@@ -489,7 +494,7 @@ function updateHoverState() {
     appState.hoveredIdx = -1;
     return;
   }
-  appState.hoveredIdx = hitTest(mouseX, mouseY);
+  appState.hoveredIdx = p5Sketch ? hitTest(p5Sketch.mouseX, p5Sketch.mouseY) : -1;
 }
 
 // ============ Lights ============
@@ -643,9 +648,9 @@ function ensureLightCaches(light) {
 
 // ======== Uniform upload ========
 function uploadUniforms() {
+  if (!p5Sketch || !glShader) return;
   const state = getRenderState();
-  // resolution
-  glShader.setUniform("u_resolution", [width, height]);
+  glShader.setUniform("u_resolution", [p5Sketch.width, p5Sketch.height]);
 
   // background linear color
   const bgLin = hexToLinearRgb(state.backgroundColor);
@@ -686,14 +691,14 @@ function uploadUniforms() {
     typeArr[i] = shape === "rect" ? 1 : isStretched ? 2 : 0;
     // match gl_FragCoord (bottom-left origin)
     posArr[i * 2 + 0] = l.x;
-    posArr[i * 2 + 1] = height - l.y;
+    posArr[i * 2 + 1] = p5Sketch.height - l.y;
     rawColorArr[i * 3 + 0] = l.colorRawLinear.r;
     rawColorArr[i * 3 + 1] = l.colorRawLinear.g;
     rawColorArr[i * 3 + 2] = l.colorRawLinear.b;
     tintColorArr[i * 3 + 0] = l.colorTintLinear.r;
     tintColorArr[i * 3 + 1] = l.colorTintLinear.g;
     tintColorArr[i * 3 + 2] = l.colorTintLinear.b;
-    intensityArr[i] = constrain(l.intensity ?? 0, 0, INTENSITY_MAX);
+    intensityArr[i] = p5Sketch.constrain(l.intensity ?? 0, 0, INTENSITY_MAX);
     let sizePx = 0;
     let minHalfSize = 0;
     if (shape === "circle") {
@@ -710,16 +715,16 @@ function uploadUniforms() {
       rectSizeArr[i * 2 + 1] = Math.max(1, l.height || 1);
     }
     sizeArr[i] = sizePx;
-    const t = constrain((l.feather ?? 150) / FEATHER_UI_MAX, 0, 1);
+    const t = p5Sketch.constrain((l.feather ?? 150) / FEATHER_UI_MAX, 0, 1);
     const perceptual = Math.pow(t, 2.2);
     const featherPx = perceptual * Math.min(FEATHER_PX_CAP, sizePx);
     const capByInward = (minHalfSize * 0.9) / Math.max(IN_RATIO, 1e-6);
     const MAX_SPILL = minHalfSize * 0.4; // tuning point
     const capByOutward = MAX_SPILL / Math.max(OUT_RATIO, 1e-6);
     featherArr[i] = Math.min(featherPx, capByInward, capByOutward);
-    falloffArr[i] = constrain(l.falloffK ?? 1.5, 0.1, 8);
+    falloffArr[i] = p5Sketch.constrain(l.falloffK ?? 1.5, 0.1, 8);
     rotationArr[i] = l.rotation ?? 0.0;
-    opacityArr[i] = constrain(l.opacity ?? 1.0, 0, 1);
+    opacityArr[i] = p5Sketch.constrain(l.opacity ?? 1.0, 0, 1);
     blendModeArr[i] = l.blendMode | 0;
   }
   if (DEBUG_LOGS) {
@@ -789,21 +794,21 @@ function updateSelectedLight(props) {
   if (l.shape === "circle") {
     if (typeof props.radius === "number") l.radius = Math.max(1, props.radius);
     if (typeof props.sizeX === "number")
-      l.sizeX = constrain(props.sizeX, 0.1, 5);
+      l.sizeX = p5Sketch ? p5Sketch.constrain(props.sizeX, 0.1, 5) : props.sizeX;
     if (typeof props.sizeY === "number")
-      l.sizeY = constrain(props.sizeY, 0.1, 5);
+      l.sizeY = p5Sketch ? p5Sketch.constrain(props.sizeY, 0.1, 5) : props.sizeY;
   } else {
     if (typeof props.width === "number") l.width = Math.max(1, props.width);
     if (typeof props.height === "number") l.height = Math.max(1, props.height);
   }
   if (typeof props.intensity === "number")
-    l.intensity = constrain(props.intensity, 0, INTENSITY_MAX);
+    l.intensity = p5Sketch ? p5Sketch.constrain(props.intensity, 0, INTENSITY_MAX) : props.intensity;
   if (typeof props.feather === "number") l.feather = Math.max(0, props.feather);
   if (typeof props.falloffK === "number")
-    l.falloffK = constrain(props.falloffK, 0.1, 8);
+    l.falloffK = p5Sketch ? p5Sketch.constrain(props.falloffK, 0.1, 8) : props.falloffK;
   if (typeof props.rotation === "number") l.rotation = props.rotation;
   if (typeof props.opacity === "number") {
-    l.opacity = constrain(props.opacity, 0, 1);
+    l.opacity = p5Sketch ? p5Sketch.constrain(props.opacity, 0, 1) : props.opacity;
     if (DEBUG_LOGS) {
       console.log("[opacity] selected=", l.id, "opacity=", l.opacity);
     }
@@ -846,8 +851,9 @@ function getState() {
 }
 
 function addLayerAtCenter(type) {
-  const cx = Math.round(width / 2);
-  const cy = Math.round(height / 2);
+  if (!p5Sketch) return;
+  const cx = Math.round(p5Sketch.width / 2);
+  const cy = Math.round(p5Sketch.height / 2);
   const light = createLightAt(cx, cy, appState.creationShape, type);
   appState.lights.push(light);
   appState.selectedLightId = light.id;
@@ -965,8 +971,8 @@ function sanitizeLight(raw) {
       : "light-" + Math.random().toString(36).slice(2, 10);
 
   const layerType = resolveLayerType(raw);
-  const canvasW = Math.max(1, width || 1);
-  const canvasH = Math.max(1, height || 1);
+  const canvasW = Math.max(1, (p5Sketch && p5Sketch.width) || 1);
+  const canvasH = Math.max(1, (p5Sketch && p5Sketch.height) || 1);
   const maxRectW = Math.max(10, canvasW * 2);
   const maxRectH = Math.max(10, canvasH * 2);
   const maxRadius = Math.max(
@@ -1114,7 +1120,10 @@ function resetCurrentDisplayToDefault() {
 function resetAllDisplaysToDefault() {
   ["1", "2", "3", "4", "5", "6"].forEach((id) => resetDisplayToDefault(id));
   const currentId = getDisplayTargetId();
-  applyPresetToState(appState, displayStateMap[currentId] || getDefaultPreset());
+  applyPresetToState(
+    appState,
+    displayStateMap[currentId] || getDefaultPreset()
+  );
 }
 
 function applyPreset(preset, options) {
@@ -1135,7 +1144,10 @@ function applyPreset(preset, options) {
       }
     });
     const currentId = getDisplayTargetId();
-    applyPresetToState(appState, displayStateMap[currentId] || getDefaultPreset());
+    applyPresetToState(
+      appState,
+      displayStateMap[currentId] || getDefaultPreset()
+    );
     return true;
   }
 
@@ -1169,6 +1181,9 @@ function applyPreset(preset, options) {
   }
   return true;
 }
+
+// p5 인스턴스 모드로 스케치 시작
+initP5Sketch();
 
 // expose API
 window.app = {

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,13 @@
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  const role = params.get("role");
+  const nav = document.getElementById("nav-page");
+  const app = document.getElementById("app-page");
+  if (role === "control" || role === "display") {
+    if (nav) nav.hidden = true;
+    if (app) app.hidden = false;
+  } else {
+    if (nav) nav.hidden = false;
+    if (app) app.hidden = true;
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "lighting-poc",
+  "version": "1.0.0",
+  "main": "main.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.95.3",
+    "p5": "^1.9.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/the-stairs/lighting-poc.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/the-stairs/lighting-poc/issues"
+  },
+  "homepage": "https://github.com/the-stairs/lighting-poc#readme",
+  "description": "",
+  "devDependencies": {
+    "vite": "^7.3.1"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,76 @@ body {
     Apple Color Emoji, Segoe UI Emoji;
 }
 
+/* 루트 네비게이션 페이지 */
+.nav-page {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+.nav-page[hidden] {
+  display: none;
+}
+.nav-inner {
+  text-align: center;
+  padding: 2rem;
+}
+.nav-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+.nav-desc {
+  margin: 0 0 2rem 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  max-width: 360px;
+}
+.nav-link {
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid #333;
+  border-radius: 8px;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.15s, border-color 0.15s;
+}
+.nav-link:hover {
+  background: #252525;
+  border-color: var(--accent);
+  color: var(--text);
+}
+.nav-link-control {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 500;
+}
+.nav-link-control:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+.app-page[hidden] {
+  display: none;
+}
+.app-page {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+
 .panel {
   position: fixed;
   top: 0;
@@ -266,6 +336,11 @@ button:disabled {
 /* p5 canvas fills container */
 canvas {
   display: block;
+}
+
+/* Display role: hide panel, full-screen canvas only */
+body.role-display .panel {
+  display: none;
 }
 
 /* Panel toggle */

--- a/styles.css
+++ b/styles.css
@@ -157,6 +157,8 @@ details.group > summary + * {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 .col {
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -253,6 +253,12 @@ button:disabled {
   pointer-events: none;
 }
 
+#displaySelect {
+  width: 100%;
+  min-width: 0;
+  margin-top: 4px;
+}
+
 #rect-size {
   display: none;
 }

--- a/supabase.js
+++ b/supabase.js
@@ -1,0 +1,18 @@
+// CDN UMD (window.supabase) 사용, config.js의 window 변수 사용
+(function () {
+  const url =
+    typeof window.SUPABASE_URL !== "undefined" ? window.SUPABASE_URL : "";
+  const key =
+    typeof window.SUPABASE_ANON_KEY !== "undefined"
+      ? window.SUPABASE_ANON_KEY
+      : "";
+  if (!url || !key) {
+    console.warn(
+      "[supabase] SUPABASE_URL 또는 SUPABASE_ANON_KEY가 없습니다. config.js를 설정하세요."
+    );
+  }
+  window.supabaseClient =
+    window.supabase && typeof window.supabase.createClient === "function"
+      ? window.supabase.createClient(url, key)
+      : null;
+})();

--- a/supabase.js
+++ b/supabase.js
@@ -1,18 +1,24 @@
-// CDN UMD (window.supabase) 사용, config.js의 window 변수 사용
-(function () {
-  const url =
-    typeof window.SUPABASE_URL !== "undefined" ? window.SUPABASE_URL : "";
-  const key =
-    typeof window.SUPABASE_ANON_KEY !== "undefined"
-      ? window.SUPABASE_ANON_KEY
-      : "";
-  if (!url || !key) {
-    console.warn(
-      "[supabase] SUPABASE_URL 또는 SUPABASE_ANON_KEY가 없습니다. config.js를 설정하세요."
-    );
-  }
-  window.supabaseClient =
-    window.supabase && typeof window.supabase.createClient === "function"
-      ? window.supabase.createClient(url, key)
-      : null;
-})();
+import { createClient } from "@supabase/supabase-js";
+
+const url =
+  (typeof import.meta !== "undefined" && import.meta.env?.VITE_SUPABASE_URL) ||
+  (typeof window !== "undefined" && window.SUPABASE_URL) ||
+  "";
+const key =
+  (typeof import.meta !== "undefined" &&
+    import.meta.env?.VITE_SUPABASE_ANON_KEY) ||
+  (typeof window !== "undefined" && window.SUPABASE_ANON_KEY) ||
+  "";
+
+if (!url || !key) {
+  console.warn(
+    "[supabase] SUPABASE_URL 또는 SUPABASE_ANON_KEY가 없습니다. .env 또는 config.js를 설정하세요."
+  );
+}
+
+export const supabaseClient =
+  url && key ? createClient(url, key) : null;
+
+if (typeof window !== "undefined") {
+  window.supabaseClient = supabaseClient;
+}

--- a/ui.js
+++ b/ui.js
@@ -81,8 +81,20 @@ document.addEventListener("DOMContentLoaded", () => {
   const addSolidBtn = $("#addSolidBtn");
   const opacityLabel = $("#opacityLabel");
 
+  const displaySelect = $("#displaySelect");
+
   // shape radios
   const shapeRadios = document.querySelectorAll('input[name="shape"]');
+
+  if (displaySelect) {
+    displaySelect.addEventListener("change", () => {
+      const targetId = displaySelect.value || "all";
+      dispatchEvent(new CustomEvent("app:displayTargetChanged", { detail: { targetId } }));
+      if (window.app && typeof window.app.setEditTarget === "function") {
+        window.app.setEditTarget(targetId);
+      }
+    });
+  }
 
   function ensureAppReady(cb) {
     if (window.app) {

--- a/ui.js
+++ b/ui.js
@@ -332,8 +332,11 @@ document.addEventListener("DOMContentLoaded", () => {
           alert("앱이 아직 준비되지 않았습니다. 잠시 후 다시 시도해주세요.");
           return;
         }
-
-        const preset = window.app.exportPreset();
+        const scopeEl = document.querySelector('input[name="presetScope"]:checked');
+        const applyToAllDisplays = scopeEl && scopeEl.value === "all";
+        const preset = window.app.exportPreset({
+          applyToAllDisplays: applyToAllDisplays,
+        });
         const json = JSON.stringify(preset, null, 2);
         const blob = new Blob([json], { type: "application/json" });
         const url = URL.createObjectURL(blob);
@@ -379,7 +382,11 @@ document.addEventListener("DOMContentLoaded", () => {
         try {
           const text = await file.text();
           const obj = JSON.parse(text);
-          const ok = window.app.importPreset(obj);
+          const scopeEl = document.querySelector('input[name="presetScope"]:checked');
+          const applyToAllDisplays = scopeEl && scopeEl.value === "all";
+          const ok = window.app.importPreset(obj, {
+            applyToAllDisplays: applyToAllDisplays,
+          });
           if (!ok) alert("프리셋 형식이 올바르지 않습니다.");
           syncFalloffCFromState();
         } catch (err) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: ".",
+  publicDir: "public",
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
# Supabase Realtime 기반 멀티 디스플레이 + Vite 마이그레이션

## 요약
- Supabase Realtime Broadcast로 컨트롤 ↔ 디스플레이 실시간 동기화
- 디스플레이별 설정 저장/복원, 프리셋 범위(현재 디스플레이 / 전체) 지원
- 빌드 도구를 Vite로 마이그레이션 (Supabase, p5 npm 패키지, ES 모듈)

## 변경 사항

### ✨ 기능
- **Supabase Realtime**: 채널 `poc-light-sync`로 컨트롤러 상태를 디스플레이에 실시간 전송
- **멀티 디스플레이**: Display 1~6 선택, 디스플레이별 `displayStateMap`에 스냅샷 저장
- **REQUEST_LIVE**: 디스플레이 접속 시 해당 타깃의 최신 상태 요청 → 컨트롤러가 응답
- **프리셋 범위**: "현재 디스플레이만" / "모든 디스플레이" 내보내기·불러오기 (all 형식 지원)
- **임포트 시 초기화**: 범위에 따라 현재/전체 디스플레이 기본값 리셋 후 적용

### 🎨 UI
<img width="1906" height="778" alt="image" src="https://github.com/user-attachments/assets/7e82f327-8801-4441-a440-44d33ed33153" />

- 루트 네비 페이지: 컨트롤 / Top·Bottom·Left·Right·Front·Back 링크

<img width="313" height="877" alt="image" src="https://github.com/user-attachments/assets/5d1d165b-cb30-49ed-a988-a9e97601bcdb" />

- 디스플레이 선택 셀렉트 (Display 1~6, 포지션별 이름) 추가
- 패널 소제목을 `<details>`/`<summary>` 토글로 변경

### ♻️ 인프라/빌드
- **Vite** 도입: `npm run dev` / `build`로 실행 및 빌드
- **p5**: CDN 제거 → `p5` npm, 인스턴스 모드로 `main.js` 리팩터링
- **스크립트**: `nav.js`, `main.js`, `ui.js` 모두 `type="module"`, Vite 번들 포함

### 🔧 기타
- 환경변수 설정은 SlashPage의 ENV 메뉴 참고부탁드립니다.